### PR TITLE
Make non-constexpr functions inline

### DIFF
--- a/test/CMakeLists.txt.in
+++ b/test/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           v1.13.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Since these are implemented in a header file, must be declared inline, otherwise it can lead to compilation failure when two compilation units containing these functions are linked.

This also adds a missing header, and fixes googletest version.